### PR TITLE
Update README to reflect ASP.NET Core usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ page_type: sample
 languages:
 - csharp
 products:
-- aspnet
+- aspnet-core
 - azure-event-grid
 description: A modern Blazor application for viewing Azure EventGrid messages in real-time using ASP.NET Core Blazor and SignalR.
 urlFragment: eventgrid-viewer-blazor


### PR DESCRIPTION
The `aspnet` value is deprecated.

https://learn.microsoft.com/en-us/help/platform/metadata-taxonomies/product#planned-for-deprecation